### PR TITLE
Support Laravel 6.*

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: php
 
 php:
-  - 7.0
   - 7.1
   - 7.2
 

--- a/composer.json
+++ b/composer.json
@@ -11,14 +11,14 @@
         }
     ],
     "require": {
-      "php": ">=7.0.0",
-      "illuminate/support": "5.5.*||5.6.*||5.7.*||5.8.*",
-      "illuminate/http": "5.5.*||5.6.*||5.7.*||5.8.*",
-      "illuminate/database": "5.5.*||5.6.*||5.7.*||5.8.*"
+      "php": ">=7.1.0",
+      "illuminate/support": "5.5.*|5.6.*|5.7.*|5.8.*|6.*",
+      "illuminate/http": "5.5.*|5.6.*|5.7.*|5.8.*|6.*",
+      "illuminate/database": "5.5.*|5.6.*|5.7.*|5.8.*|6.*"
     },
     "require-dev": {
-      "orchestra/testbench": "~3.5",
-      "phpunit/phpunit": "~6.0"
+      "orchestra/testbench": "~3.5|~4.2",
+      "phpunit/phpunit": "~6.0|~7.0|~8.0"
     },
     "autoload": {
         "psr-4": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -7,8 +7,7 @@
          convertNoticesToExceptions="true"
          convertWarningsToExceptions="true"
          processIsolation="false"
-         stopOnFailure="false"
-         syntaxCheck="false">
+         stopOnFailure="false">
     <testsuites>
         <testsuite name="Package Test Suite">
             <directory suffix="Test.php">./tests/</directory>

--- a/src/CursorPaginator.php
+++ b/src/CursorPaginator.php
@@ -11,6 +11,7 @@ use Illuminate\Http\Request;
 use Illuminate\Pagination\AbstractPaginator;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Collection;
+use Illuminate\Support\Str;
 use IteratorAggregate;
 use JsonSerializable;
 
@@ -134,7 +135,8 @@ class CursorPaginator extends AbstractPaginator implements Arrayable, ArrayAcces
         $transform_name = config('cursor_pagination.transform_name', null);
 
         if (!is_null($transform_name)) {
-            return call_user_func($transform_name, $name);
+            $str_method = Str::replaceLast('_case', '', $transform_name);
+            return Str::$str_method($name);
         }
 
         return $name;
@@ -231,7 +233,7 @@ class CursorPaginator extends AbstractPaginator implements Arrayable, ArrayAcces
         $query = array_merge($this->query, $cursor);
 
         return $this->path
-            . (str_contains($this->path, '?') ? '&' : '?')
+            . (Str::contains($this->path, '?') ? '&' : '?')
             . http_build_query($query, '', '&')
             . $this->buildFragment();
     }

--- a/src/CursorPaginator.php
+++ b/src/CursorPaginator.php
@@ -55,7 +55,7 @@ class CursorPaginator extends AbstractPaginator implements Arrayable, ArrayAcces
      * Create a new paginator instance.
      *
      * @param mixed $items
-     * @param int $perPage
+     * @param int   $perPage
      * @param array $options
      */
     public function __construct($items, $perPage, array $options = [])
@@ -136,6 +136,7 @@ class CursorPaginator extends AbstractPaginator implements Arrayable, ArrayAcces
 
         if (!is_null($transform_name)) {
             $str_method = Str::replaceLast('_case', '', $transform_name);
+
             return Str::$str_method($name);
         }
 
@@ -233,9 +234,9 @@ class CursorPaginator extends AbstractPaginator implements Arrayable, ArrayAcces
         $query = array_merge($this->query, $cursor);
 
         return $this->path
-            . (Str::contains($this->path, '?') ? '&' : '?')
-            . http_build_query($query, '', '&')
-            . $this->buildFragment();
+            .(Str::contains($this->path, '?') ? '&' : '?')
+            .http_build_query($query, '', '&')
+            .$this->buildFragment();
     }
 
     /**
@@ -305,6 +306,7 @@ class CursorPaginator extends AbstractPaginator implements Arrayable, ArrayAcces
 
     /**
      * @param $id
+     *
      * @return int
      */
     protected function parseDateIdentifier($id): int
@@ -314,7 +316,9 @@ class CursorPaginator extends AbstractPaginator implements Arrayable, ArrayAcces
 
     /**
      * Will check if the identifier is type date.
+     *
      * @param $id
+     *
      * @return bool
      */
     protected function isDateIdentifier($id): bool
@@ -326,7 +330,7 @@ class CursorPaginator extends AbstractPaginator implements Arrayable, ArrayAcces
      * Render the paginator using a given view.
      *
      * @param string|null $view
-     * @param array $data
+     * @param array       $data
      *
      * @return string
      */
@@ -346,11 +350,11 @@ class CursorPaginator extends AbstractPaginator implements Arrayable, ArrayAcces
         list($prev, $next) = $this->getCursorQueryNames();
 
         return [
-            'data' => $this->items->toArray(),
-            'path' => $this->url(),
-            $prev => self::castCursor($this->prevCursor()),
-            $next => self::castCursor($this->nextCursor()),
-            'per_page' => (int)$this->perPage(),
+            'data'          => $this->items->toArray(),
+            'path'          => $this->url(),
+            $prev           => self::castCursor($this->prevCursor()),
+            $next           => self::castCursor($this->nextCursor()),
+            'per_page'      => (int) $this->perPage(),
             'next_page_url' => $this->nextPageUrl(),
             'prev_page_url' => $this->previousPageUrl(),
         ];
@@ -389,6 +393,6 @@ class CursorPaginator extends AbstractPaginator implements Arrayable, ArrayAcces
             return $val;
         }
 
-        return (string)$val;
+        return (string) $val;
     }
 }

--- a/tests/CursorNameTest.php
+++ b/tests/CursorNameTest.php
@@ -11,20 +11,20 @@ class CursorNameTest extends TestCase
         config(['cursor_pagination.transform_name' => 'snake_case']);
         list($prev_name, $next_name) = CursorPaginator::cursorQueryNames();
 
-        $this->assertContains('_', $prev_name);
-        $this->assertContains('_', $next_name);
+        $this->assertStringContainsString('_', $prev_name);
+        $this->assertStringContainsString('_', $next_name);
 
         config(['cursor_pagination.transform_name' => 'camel_case']);
         list($prev_name, $next_name) = CursorPaginator::cursorQueryNames();
 
-        $this->assertNotContains('_', $prev_name);
-        $this->assertNotContains('_', $next_name);
+        $this->assertStringNotContainsString('_', $prev_name);
+        $this->assertStringNotContainsString('_', $next_name);
 
         config(['cursor_pagination.transform_name' => 'kebab_case']);
         list($prev_name, $next_name) = CursorPaginator::cursorQueryNames();
 
-        $this->assertContains('-', $prev_name);
-        $this->assertContains('-', $next_name);
+        $this->assertStringContainsString('-', $prev_name);
+        $this->assertStringContainsString('-', $next_name);
 
         config(['cursor_pagination.transform_name' => null]);
     }

--- a/tests/CursorPaginationTest.php
+++ b/tests/CursorPaginationTest.php
@@ -12,7 +12,7 @@ class CursorPaginationTest extends TestCase
             ['id' => 1], ['id' => 2], ['id' => 3], ['id' => 4], ['id' => 5],
         ], $perPage = 2);
 
-        $this->assertAttributeEquals($perPage, 'perPage', $p);
+        $this->assertEquals($perPage, $p->perPage());
     }
 
     public function test_overflow_pagination()

--- a/tests/CursorTest.php
+++ b/tests/CursorTest.php
@@ -39,7 +39,7 @@ class CursorTest extends TestCase
 
         $cursor = CursorPaginator::resolveCurrentCursor($req);
 
-        $this->assertAttributeEquals($val, 'prev', $cursor, 'Cursor\'s nav should be prev');
+        $this->assertEquals($val, $cursor->getPrevCursor(), 'Cursor\'s nav should be prev');
         $this->assertFalse($cursor->isNext(), 'is not next');
         $this->assertTrue($cursor->isPrev(), 'is prev');
         $this->assertTrue($cursor->isPresent(), 'is present');
@@ -58,7 +58,7 @@ class CursorTest extends TestCase
 
         $cursor = CursorPaginator::resolveCurrentCursor($req);
 
-        $this->assertAttributeEquals($val, 'next', $cursor, "Cursor's value should be $val");
+        $this->assertEquals($val, $cursor->getNextCursor(), "Cursor's value should be $val");
         $this->assertTrue($cursor->isNext(), 'is next');
         $this->assertTrue(!$cursor->isPrev(), 'is not prev');
         $this->assertTrue($cursor->isPresent(), 'is present');
@@ -78,8 +78,8 @@ class CursorTest extends TestCase
 
         $cursor = CursorPaginator::resolveCurrentCursor($req);
 
-        $this->assertAttributeEquals($prev_val, 'prev', $cursor);
-        $this->assertAttributeEquals($next_val, 'next', $cursor);
+        $this->assertEquals($prev_val, $cursor->getPrevCursor());
+        $this->assertEquals($next_val, $cursor->getNextCursor());
         $this->assertTrue($cursor->isNext(), 'is next');
         $this->assertTrue($cursor->isPrev(), 'is prev');
     }

--- a/tests/MacroTest.php
+++ b/tests/MacroTest.php
@@ -58,7 +58,7 @@ class MacroTest extends ModelsTestCase
             'path'    => '/',
         ]);
 
-        $this->assertAttributeEquals($prev_count, 'perPage', $p);
+        $this->assertEquals($prev_count, $p->perPage());
         $this->assertEquals(count($p->toArray()['data']), $prev_count);
     }
 
@@ -71,7 +71,7 @@ class MacroTest extends ModelsTestCase
             'path'    => '/',
         ]);
 
-        $this->assertAttributeEquals($next_count, 'perPage', $p);
+        $this->assertEquals($next_count, $p->perPage());
         $this->assertEquals(count($p->toArray()['data']), $next_count);
     }
 
@@ -86,7 +86,7 @@ class MacroTest extends ModelsTestCase
             'path'    => '/',
         ]);
 
-        $this->assertAttributeEquals($next_count, 'perPage', $p);
+        $this->assertEquals($next_count, $p->perPage());
         $this->assertEquals(count($p->toArray()['data']), $next_count);
     }
 
@@ -112,8 +112,6 @@ class MacroTest extends ModelsTestCase
             'path'       => '/',
         ]);
 
-        $this->assertAttributeEquals(true, 'date_identifier', $p);
-
         $this->assertGreaterThanOrEqual(strtotime('last month'), $p->prevCursor());
         $this->assertLessThanOrEqual(strtotime('now'), $p->prevCursor());
         $this->assertGreaterThanOrEqual(strtotime('last month'), $p->nextCursor());
@@ -130,7 +128,6 @@ class MacroTest extends ModelsTestCase
                 'path'            => '/',
             ]);
 
-        $this->assertAttributeEquals(true, 'date_identifier', $p);
         $this->assertGreaterThanOrEqual(strtotime('last month'), $p->prevCursor());
         $this->assertLessThanOrEqual(strtotime('now'), $p->prevCursor());
         $this->assertGreaterThanOrEqual(strtotime('last month'), $p->nextCursor());
@@ -141,8 +138,6 @@ class MacroTest extends ModelsTestCase
     {
         $p = User::orderBy('datetime', 'asc')->cursorPaginate(10, ['*'], ['path' => '/']);
 
-        $this->assertAttributeEquals('datetime', 'identifier', $p);
-        $this->assertAttributeEquals(true, 'date_identifier', $p);
         $this->assertGreaterThanOrEqual(strtotime('last month'), $p->prevCursor());
         $this->assertLessThanOrEqual(strtotime('now'), $p->prevCursor());
         $this->assertGreaterThanOrEqual(strtotime('last month'), $p->nextCursor());

--- a/tests/ModelsTestCase.php
+++ b/tests/ModelsTestCase.php
@@ -8,7 +8,7 @@ use Juampi92\CursorPagination\Tests\Fixtures\Models\User;
 
 class ModelsTestCase extends TestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
         // Reset config on each request


### PR DESCRIPTION
* bumped minimum version of PHP to 7.1 to support phpunit 8 with return type
* syntaxCheck no longer supported in recent phpunit versions
* str helper functions have been removed
* use facade methods
* PHPUnit have deprecated a lot of functions
* date _identifier and identifier are protected and can no longer be tested, the subsequent tests cover this anyway