### PR TITLE
use having instead of where

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,9 +12,9 @@
     ],
     "require": {
       "php": ">=7.1.0",
-      "illuminate/support": "5.5.*|5.6.*|5.7.*|5.8.*|6.*|7.*",
-      "illuminate/http": "5.5.*|5.6.*|5.7.*|5.8.*|6.*|7.*",
-      "illuminate/database": "5.5.*|5.6.*|5.7.*|5.8.*|6.*|7.*"
+      "illuminate/support": "^5.5|^6|^7|^8",
+      "illuminate/http": "^5.5|^6|^7|^8",
+      "illuminate/database": "^5.5|^6|^7|^8"
     },
     "require-dev": {
       "orchestra/testbench": "~3.5|~4.2",

--- a/src/CursorPaginationServiceProvider.php
+++ b/src/CursorPaginationServiceProvider.php
@@ -101,10 +101,10 @@ class CursorPaginationServiceProvider extends ServiceProvider
             $identifier_sort_inverted = $identifier_sort ? $identifier_sort['direction'] === 'desc' : false;
 
             if ($cursor->isPrev()) {
-                $this->where($options['identifier'], $identifier_sort_inverted ? '>' : '<', $cursor->getPrevQuery());
+                $this->having($options['identifier'], $identifier_sort_inverted ? '>' : '<', $cursor->getPrevQuery());
             }
             if ($cursor->isNext()) {
-                $this->where($options['identifier'], $identifier_sort_inverted ? '<' : '>', $cursor->getNextQuery());
+                $this->having($options['identifier'], $identifier_sort_inverted ? '<' : '>', $cursor->getNextQuery());
             }
 
             // Use configs perPage if it's not defined


### PR DESCRIPTION
This enables the use of calculated fields as cursor.

We were hitting an issue creating an activity feed where a lot of things happen in the same request. The precision in the `created_at` was to the second so we were missing some entries.

The below code works by adding id as a microsecond creating a unique cursor to sort by.

We need to use having as the cursor is now calculated and can't be used in where.

I can't see a downfall in moving the cursor to the `HAVING` over the `WHERE`. This should be backward compatible.

```php
Activity::query()
    ->select([
        '*', 
        DB::raw('CAST(UNIX_TIMESTAMP(created_at + interval id microsecond) * 1000000 as UNSIGNED) as `cursor`'),
    ])
    ->orderBy('cursor')
    ->cursorPaginate();
```