### PR TITLE
update nextCursor to always try to return the latest possible cursor

### DIFF
--- a/src/CursorPaginator.php
+++ b/src/CursorPaginator.php
@@ -157,7 +157,12 @@ class CursorPaginator extends AbstractPaginator implements Arrayable, ArrayAcces
 
     public function nextCursor()
     {
-        return $this->hasMorePages() ? $this->lastItem() : null;
+        if ($this->hasMorePages()) {
+            return $this->lastItem();
+        }
+
+        list(, $next_name) = self::cursorQueryNames();
+        return $this->lastItem() ?? $this->request->get($next_name);
     }
 
     /**

--- a/src/CursorPaginator.php
+++ b/src/CursorPaginator.php
@@ -162,6 +162,7 @@ class CursorPaginator extends AbstractPaginator implements Arrayable, ArrayAcces
         }
 
         list(, $next_name) = self::cursorQueryNames();
+
         return $this->lastItem() ?? $this->request->get($next_name);
     }
 

--- a/src/CursorPaginator.php
+++ b/src/CursorPaginator.php
@@ -55,7 +55,7 @@ class CursorPaginator extends AbstractPaginator implements Arrayable, ArrayAcces
      * Create a new paginator instance.
      *
      * @param mixed $items
-     * @param int $perPage
+     * @param int   $perPage
      * @param array $options
      */
     public function __construct($items, $perPage, array $options = [])
@@ -239,9 +239,9 @@ class CursorPaginator extends AbstractPaginator implements Arrayable, ArrayAcces
         $query = array_merge($this->query, $cursor);
 
         return $this->path
-            . (Str::contains($this->path, '?') ? '&' : '?')
-            . http_build_query($query, '', '&')
-            . $this->buildFragment();
+            .(Str::contains($this->path, '?') ? '&' : '?')
+            .http_build_query($query, '', '&')
+            .$this->buildFragment();
     }
 
     /**
@@ -335,7 +335,7 @@ class CursorPaginator extends AbstractPaginator implements Arrayable, ArrayAcces
      * Render the paginator using a given view.
      *
      * @param string|null $view
-     * @param array $data
+     * @param array       $data
      *
      * @return string
      */
@@ -355,11 +355,11 @@ class CursorPaginator extends AbstractPaginator implements Arrayable, ArrayAcces
         list($prev, $next) = $this->getCursorQueryNames();
 
         return [
-            'data' => $this->items->toArray(),
-            'path' => $this->url(),
-            $prev => self::castCursor($this->prevCursor()),
-            $next => self::castCursor($this->nextCursor()),
-            'per_page' => (int)$this->perPage(),
+            'data'          => $this->items->toArray(),
+            'path'          => $this->url(),
+            $prev           => self::castCursor($this->prevCursor()),
+            $next           => self::castCursor($this->nextCursor()),
+            'per_page'      => (int) $this->perPage(),
             'next_page_url' => $this->nextPageUrl(),
             'prev_page_url' => $this->previousPageUrl(),
         ];
@@ -398,6 +398,6 @@ class CursorPaginator extends AbstractPaginator implements Arrayable, ArrayAcces
             return $val;
         }
 
-        return (string)$val;
+        return (string) $val;
     }
 }

--- a/src/CursorPaginator.php
+++ b/src/CursorPaginator.php
@@ -55,7 +55,7 @@ class CursorPaginator extends AbstractPaginator implements Arrayable, ArrayAcces
      * Create a new paginator instance.
      *
      * @param mixed $items
-     * @param int   $perPage
+     * @param int $perPage
      * @param array $options
      */
     public function __construct($items, $perPage, array $options = [])
@@ -239,9 +239,9 @@ class CursorPaginator extends AbstractPaginator implements Arrayable, ArrayAcces
         $query = array_merge($this->query, $cursor);
 
         return $this->path
-            .(Str::contains($this->path, '?') ? '&' : '?')
-            .http_build_query($query, '', '&')
-            .$this->buildFragment();
+            . (Str::contains($this->path, '?') ? '&' : '?')
+            . http_build_query($query, '', '&')
+            . $this->buildFragment();
     }
 
     /**
@@ -335,7 +335,7 @@ class CursorPaginator extends AbstractPaginator implements Arrayable, ArrayAcces
      * Render the paginator using a given view.
      *
      * @param string|null $view
-     * @param array       $data
+     * @param array $data
      *
      * @return string
      */
@@ -355,11 +355,11 @@ class CursorPaginator extends AbstractPaginator implements Arrayable, ArrayAcces
         list($prev, $next) = $this->getCursorQueryNames();
 
         return [
-            'data'          => $this->items->toArray(),
-            'path'          => $this->url(),
-            $prev           => self::castCursor($this->prevCursor()),
-            $next           => self::castCursor($this->nextCursor()),
-            'per_page'      => (int) $this->perPage(),
+            'data' => $this->items->toArray(),
+            'path' => $this->url(),
+            $prev => self::castCursor($this->prevCursor()),
+            $next => self::castCursor($this->nextCursor()),
+            'per_page' => (int)$this->perPage(),
             'next_page_url' => $this->nextPageUrl(),
             'prev_page_url' => $this->previousPageUrl(),
         ];
@@ -398,6 +398,6 @@ class CursorPaginator extends AbstractPaginator implements Arrayable, ArrayAcces
             return $val;
         }
 
-        return (string) $val;
+        return (string)$val;
     }
 }

--- a/tests/CursorPaginationTest.php
+++ b/tests/CursorPaginationTest.php
@@ -40,7 +40,7 @@ class CursorPaginationTest extends TestCase
         $this->assertEquals($p->prevCursor(), 1);
     }
 
-    public function test_empty_next_if_no_more()
+    public function test_returns_last_cursor_as_next_if_no_more()
     {
         $p = new CursorPaginator($array = [
             (object) ['id' => 1],
@@ -48,6 +48,6 @@ class CursorPaginationTest extends TestCase
             (object) ['id' => 3],
         ], $perPage = 3);
 
-        $this->assertEquals($p->nextCursor(), null);
+        $this->assertEquals(3, $p->nextCursor());
     }
 }

--- a/tests/RequestTest.php
+++ b/tests/RequestTest.php
@@ -138,24 +138,26 @@ class RequestTest extends ModelsTestCase
 
         $response = $this->get("/test/resource?$prev_name=$prev_cur&$next_name=$next_cur");
 
+        $data = json_decode($response->getOriginalContent())->data;
+        $ids = collect($data)->pluck('_id')->all();
+        $latest_id = collect($data)->pluck('_id')->last();
+
         $response->assertJsonFragment(['links' => [
             'first' => null,
             'last'  => null,
             'prev'  => null,
-            'next'  => null,
+            'next'  => "test/resource?$next_name=$latest_id&$prev_name=$prev_cur",
         ]]);
 
         $response->assertJsonFragment([
             'meta' => [
                 'path'            => 'test/resource?',
-                'next_cursor'     => null,
+                'next_cursor'     => "$latest_id",
                 'per_page'        => 5,
                 'previous_cursor' => null,
             ],
         ]);
 
-        $data = json_decode($response->getOriginalContent())->data;
-        $ids = collect($data)->pluck('_id')->all();
         $this->assertEquals($ids, range($next_cur + 1, min($next_cur + 5, $prev_cur - 1)));
     }
 

--- a/tests/UrlDetectionTest.php
+++ b/tests/UrlDetectionTest.php
@@ -10,12 +10,12 @@ class UrlDetectionTest extends TestCase
     public function test_resolves_urls_on_no_cursor()
     {
         $p = new CursorPaginator($array = [
-            (object) ['id' => 1],
-            (object) ['id' => 2],
-            (object) ['id' => 3],
+            (object)['id' => 1],
+            (object)['id' => 2],
+            (object)['id' => 3],
         ], $perPage = 2, [
             'request' => new Request(),
-            'path'    => $path = 'api',
+            'path' => $path = 'api',
         ]);
 
         $firstId = $array[0]->id;
@@ -35,14 +35,14 @@ class UrlDetectionTest extends TestCase
         list(, $next_name) = CursorPaginator::cursorQueryNames();
 
         $p = new CursorPaginator($array = [
-            (object) ['id' => 2],
-            (object) ['id' => 3],
-            (object) ['id' => 4],
+            (object)['id' => 2],
+            (object)['id' => 3],
+            (object)['id' => 4],
         ], $perPage = 2, [
             'request' => new Request([
                 $next_name => 1,
             ]),
-            'path'    => $path = 'api',
+            'path' => $path = 'api',
         ]);
 
         $lastId = $array[$perPage - 1]->id;
@@ -59,15 +59,15 @@ class UrlDetectionTest extends TestCase
         list(, $next_name) = CursorPaginator::cursorQueryNames();
 
         $p = new CursorPaginator($array = [
-            (object) ['id' => 2],
-            (object) ['id' => 3],
-            (object) ['id' => 4],
+            (object)['id' => 2],
+            (object)['id' => 3],
+            (object)['id' => 4],
         ], $perPage = 2, [
             'request' => new Request([
-                'a'        => 'b',
+                'a' => 'b',
                 $next_name => 1,
             ]),
-            'path'    => $path = 'api',
+            'path' => $path = 'api',
         ]);
 
         $lastId = $array[$perPage - 1]->id;
@@ -83,7 +83,7 @@ class UrlDetectionTest extends TestCase
             'request' => new Request([
                 $prev_name => $prev_query = 1,
             ]),
-            'path'    => $path = 'api',
+            'path' => $path = 'api',
         ]);
 
         $this->assertEquals($p->previousPageUrl(), "$path?$prev_name=$prev_query");
@@ -94,18 +94,18 @@ class UrlDetectionTest extends TestCase
         list(, $next_name) = CursorPaginator::cursorQueryNames();
 
         $p = new CursorPaginator($array = [
-            (object) ['id' => 98],
-            (object) ['id' => 99],
+            (object)['id' => 98],
+            (object)['id' => 99],
         ], $perPage = 2, [
             'request' => new Request([
                 $next_name => $next_query = 97,
             ]),
-            'path'    => $path = 'api',
+            'path' => $path = 'api',
         ]);
 
         $this->assertNotTrue($p->hasMorePages());
-        $this->assertEquals( "$path?$next_name=99",$p->nextPageUrl());
-        $this->assertEquals( null,$p->previousPageUrl());
+        $this->assertEquals("$path?$next_name=99", $p->nextPageUrl());
+        $this->assertEquals(null, $p->previousPageUrl());
     }
 
     public function test_different_identifier()
@@ -113,11 +113,11 @@ class UrlDetectionTest extends TestCase
         CursorPaginator::cursorQueryNames();
 
         $p = new CursorPaginator($array = [
-            (object) ['id' => 98, '_id' => 1],
-            (object) ['id' => 99, '_id' => 2],
-            (object) ['id' => 100, '_id' => 3],
+            (object)['id' => 98, '_id' => 1],
+            (object)['id' => 99, '_id' => 2],
+            (object)['id' => 100, '_id' => 3],
         ], $perPage = 2, [
-            'request'    => new Request(),
+            'request' => new Request(),
             'identifier' => '_id',
         ]);
 

--- a/tests/UrlDetectionTest.php
+++ b/tests/UrlDetectionTest.php
@@ -89,7 +89,7 @@ class UrlDetectionTest extends TestCase
         $this->assertEquals($p->previousPageUrl(), "$path?$prev_name=$prev_query");
     }
 
-    public function test_stops_when_no_more_items()
+    public function test_returns_last_cursor_when_no_more_items()
     {
         list(, $next_name) = CursorPaginator::cursorQueryNames();
 
@@ -104,8 +104,8 @@ class UrlDetectionTest extends TestCase
         ]);
 
         $this->assertNotTrue($p->hasMorePages());
-        $this->assertEquals($p->nextPageUrl(), null);
-        $this->assertEquals($p->previousPageUrl(), null);
+        $this->assertEquals( "$path?$next_name=99",$p->nextPageUrl());
+        $this->assertEquals( null,$p->previousPageUrl());
     }
 
     public function test_different_identifier()

--- a/tests/UrlDetectionTest.php
+++ b/tests/UrlDetectionTest.php
@@ -10,12 +10,12 @@ class UrlDetectionTest extends TestCase
     public function test_resolves_urls_on_no_cursor()
     {
         $p = new CursorPaginator($array = [
-            (object)['id' => 1],
-            (object)['id' => 2],
-            (object)['id' => 3],
+            (object) ['id' => 1],
+            (object) ['id' => 2],
+            (object) ['id' => 3],
         ], $perPage = 2, [
             'request' => new Request(),
-            'path' => $path = 'api',
+            'path'    => $path = 'api',
         ]);
 
         $firstId = $array[0]->id;
@@ -35,14 +35,14 @@ class UrlDetectionTest extends TestCase
         list(, $next_name) = CursorPaginator::cursorQueryNames();
 
         $p = new CursorPaginator($array = [
-            (object)['id' => 2],
-            (object)['id' => 3],
-            (object)['id' => 4],
+            (object) ['id' => 2],
+            (object) ['id' => 3],
+            (object) ['id' => 4],
         ], $perPage = 2, [
             'request' => new Request([
                 $next_name => 1,
             ]),
-            'path' => $path = 'api',
+            'path'    => $path = 'api',
         ]);
 
         $lastId = $array[$perPage - 1]->id;
@@ -59,15 +59,15 @@ class UrlDetectionTest extends TestCase
         list(, $next_name) = CursorPaginator::cursorQueryNames();
 
         $p = new CursorPaginator($array = [
-            (object)['id' => 2],
-            (object)['id' => 3],
-            (object)['id' => 4],
+            (object) ['id' => 2],
+            (object) ['id' => 3],
+            (object) ['id' => 4],
         ], $perPage = 2, [
             'request' => new Request([
-                'a' => 'b',
+                'a'        => 'b',
                 $next_name => 1,
             ]),
-            'path' => $path = 'api',
+            'path'    => $path = 'api',
         ]);
 
         $lastId = $array[$perPage - 1]->id;
@@ -83,7 +83,7 @@ class UrlDetectionTest extends TestCase
             'request' => new Request([
                 $prev_name => $prev_query = 1,
             ]),
-            'path' => $path = 'api',
+            'path'    => $path = 'api',
         ]);
 
         $this->assertEquals($p->previousPageUrl(), "$path?$prev_name=$prev_query");
@@ -94,13 +94,13 @@ class UrlDetectionTest extends TestCase
         list(, $next_name) = CursorPaginator::cursorQueryNames();
 
         $p = new CursorPaginator($array = [
-            (object)['id' => 98],
-            (object)['id' => 99],
+            (object) ['id' => 98],
+            (object) ['id' => 99],
         ], $perPage = 2, [
             'request' => new Request([
                 $next_name => $next_query = 97,
             ]),
-            'path' => $path = 'api',
+            'path'    => $path = 'api',
         ]);
 
         $this->assertNotTrue($p->hasMorePages());
@@ -113,11 +113,11 @@ class UrlDetectionTest extends TestCase
         CursorPaginator::cursorQueryNames();
 
         $p = new CursorPaginator($array = [
-            (object)['id' => 98, '_id' => 1],
-            (object)['id' => 99, '_id' => 2],
-            (object)['id' => 100, '_id' => 3],
+            (object) ['id' => 98, '_id' => 1],
+            (object) ['id' => 99, '_id' => 2],
+            (object) ['id' => 100, '_id' => 3],
         ], $perPage = 2, [
-            'request' => new Request(),
+            'request'    => new Request(),
             'identifier' => '_id',
         ]);
 


### PR DESCRIPTION
### Referenced Issues

none

### Problem Definition

While the package in a project, my teammates where wondering if  it in case of last pagination request they are able to get the  latest cursor. so that if the last page contains no items/items count less than page size, they can re-call the this last request to fetch newer data if it exists.

### What does this implement/fix

To Achieve this, the nextCursor method now 
* tries to get the last item if there are no more pages but still has some items. so get the last cursor from the last item
* if there are no data at all, always will return a cursor from the next query string
* if nothing exists at all then return the default null value

### Possible updates

The current implementation can be set from configuration file whether the user wants the last request to have null value or a possible next cursor